### PR TITLE
fix: when widget closed stop watching payment

### DIFF
--- a/files/assets/lnme.js
+++ b/files/assets/lnme.js
@@ -210,6 +210,11 @@ class LnMe {
       shouldSetHash: false
     });
     this.target = document.querySelector('.jPopup .content').firstElementChild;
+
+    // When popup is closed, we stop watching the payment.
+    document.querySelector('.jCloseBtn').addEventListener('click', (e) => {
+      this.stopWatchingPayment();
+    });
   }
 
   thanks() {


### PR DESCRIPTION
When widget was closed, it was still watching the payment. I guess it should be stopped when it is closed so it is not polling to the server without a reason.

It works when I run it but I guess it would require to update `rice-box.go` in order to have it in the binaries. I have tried following the instruction in `README.md` but  when I run `rice embed-go` it creates a `rice-box.go` that does not look right to me.