### PR TITLE
Better error logging for the LNURL endpoint

### DIFF
--- a/lnme.go
+++ b/lnme.go
@@ -144,7 +144,7 @@ func main() {
 	})
 
 	if !cfg.Bool("disable-ln-address") {
-		e.GET("/.well-known/lnurlp/:name", func(c echo.Context) error {
+		lnurlHandler := func(c echo.Context) error {
 			name := c.Param("name")
 			lightningAddress := name + "@" + c.Request().Host
 			lnurlMetadata := "[[\"text/identifier\", \"" + lightningAddress + "\"], [\"text/plain\", \"Sats for " + lightningAddress + "\"]]"
@@ -183,7 +183,9 @@ func main() {
 				}
 				return c.JSON(http.StatusOK, lnurlPayResponse2)
 			}
-		})
+		}
+		e.GET("/.well-known/lnurlp/:name", lnurlHandler)
+		e.GET("/lnurlp/:name", lnurlHandler)
 	}
 
 	// Debug test endpoint


### PR DESCRIPTION
This checks for errors when creating the invoice and logs the error and returns an LNURL error response.
Before it would return a blank pr.

[fixes #21]